### PR TITLE
Makefile usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,17 @@
 # SDK_ROOT = $(shell xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk
 
 # with installed spirv_headers and spirv_cross
-spirv_headers_include_path ?= /usr/local/include
-spirv_cross_include_path ?= /usr/local/include/spirv
-spirv_cross_1_2_include_path ?= /usr/local/include/spirv/1.2
-spirv_cross_config_include_path ?= external/SPIRV-Cross
-spirv_cross_lib_path ?= /usr/local/lib
+# spirv_headers_include_path ?= /usr/local/include
+# spirv_cross_include_path ?= /usr/local/include/spirv
+# spirv_cross_1_2_include_path ?= /usr/local/include/spirv/1.2
+# spirv_cross_config_include_path ?= external/SPIRV-Cross
+# spirv_cross_lib_path ?= /usr/local/lib
 
 # with uninstalled spirv_headers and spirv_cross
 # uncomment the following lines 
-# spirv_headers_path ?= ../SPIRV-Headers/include/spirv/1.2
-# spirv_cross_include_path ?= ../SPIRV-Cross
-# spirv_cross_lib_path ?= ../SPIRV-Cross/build
+spirv_headers_path ?= ../SPIRV-Headers/include/spirv/1.2
+spirv_cross_include_path ?= ../SPIRV-Cross
+spirv_cross_lib_path ?= ../SPIRV-Cross/build
 
 # build dir
 build_dir ?= build

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a start for porting OpenGL 4.6 on top of Metal, most of it is functional
 ## GLFW support
 I modified a version of GLFW to work with MGL, it replaces the default MacOS OpenGL contexts. The changes are included in the repository and should build correctly with the MGL xcode project.
 
+(additional notes from conversy/MGL repo: the modified GLFW version is not mandatory, see below).
+
 ## Mapping OpenGL onto Metal
 I mapped as much of the functionality of Metal I could into OpenGL 4.6, it's surprising how much I was able to map directly from OpenGL state to Metal. But I suppose Metal evolved to meet market requirements and since OpenGL was in place the same features existed just in another form.
 
@@ -334,6 +336,29 @@ make install
 ```
 
 Once installed in /usr/local the Xcode project should be able to build all the required dependencies for MGL.
+
+
+## Using the Makefile and uninstalled build dependencies
+
+Install [brew](https://brew.sh).
+
+Then:
+
+```
+make install-pkgdeps
+```
+
+This will install as-much-as-regular dependencies with brew (including glfw).
+Then it git clones two directories: you should have two new directories next to MGL: SPIRV-Headers and SPIRV-Cross.
+Only SPIRV-Cross requires to be built, which is done on the last line of the `make install-pkgdeps` command.
+
+Finally,
+
+```
+make -j test
+```
+
+should compile everything and launch the test.
 
 ## Where to start
 Use the Xcode MGL project to build your own tests and projects... start by building test_mgl_glfw, this is a chunk of test code I used to get most of the functionality up and running. Xcode has all the debugging tools and won't leave you wondering WTF is that assert about, throwing your hands up and walking away without learning anything about the internals of OpenGL or contributing to this project.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Install [brew](https://brew.sh).
 Then:
 
 ```
+brew install make git
 make install-pkgdeps
 ```
 

--- a/test_mgl_glfw/main.cpp
+++ b/test_mgl_glfw/main.cpp
@@ -2828,7 +2828,7 @@ int main(int argc, const char * argv[])
     //glfwWindowHint(GLFW_WIN32_KEYBOARD_MENU, GLFW_TRUE);
 
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
     glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GL_TRUE);


### PR DESCRIPTION
This PR makes it easier to compile the lib and launch the test the from scratch using uninstalled SPIRV stuff.
It uses the regular, brew-provided glfw, but this requires to request an OpenGL 4.1 context instead of 4.6 in the test program.