### PR TITLE
mglShaderSource: fix handling of multiple sources

### DIFF
--- a/MGL/src/MGLRenderer.m
+++ b/MGL/src/MGLRenderer.m
@@ -1393,6 +1393,7 @@ void logDirtyBits(GLMContext ctx)
     __autoreleasing NSError *error = nil;
 
     library = [_device newLibraryWithSource: [NSString stringWithUTF8String: str] options: nil error: &error];
+    if(!library) NSLog(@" error compiling shader => %@ ", [error localizedDescription] );
     assert(library);
 
     return library;

--- a/MGL/src/shaders.c
+++ b/MGL/src/shaders.c
@@ -206,6 +206,8 @@ void mglShaderSource(GLMContext ctx, GLuint shader, GLsizei count, const GLchar 
     size_t len;
     char *src;
     Shader *ptr;
+    const GLint * used_length=0;
+    GLint* tmp_length=0;
 
     ERROR_CHECK_RETURN(isShader(ctx, shader), GL_INVALID_VALUE);
     ERROR_CHECK_RETURN(count >= 0, GL_INVALID_VALUE);
@@ -215,13 +217,26 @@ void mglShaderSource(GLMContext ctx, GLuint shader, GLsizei count, const GLchar 
     ERROR_CHECK_RETURN(ptr, GL_INVALID_VALUE);
 
     // calculate storage
-    if (length)
+    if (count>1)
     {
         len = 0;
-        for(int i=0; i<count; i++)
-        {
-            len += length[i];
+        if (!length) {
+            tmp_length = (GLint*) malloc(count*sizeof(GLint));
+            ERROR_CHECK_RETURN(tmp_length, GL_OUT_OF_MEMORY);
+            for(int i=0; i<count; i++)
+            {
+                tmp_length[i] = strlen(string[i]);
+                len += tmp_length[i];
+            }
+            used_length = tmp_length;
         }
+        else {
+            for(int i=0; i<count; i++)
+            {
+                len += length[i];
+            }
+            used_length = length;
+        }   
 
         ERROR_CHECK_RETURN(len, GL_INVALID_VALUE);
 
@@ -229,13 +244,11 @@ void mglShaderSource(GLMContext ctx, GLuint shader, GLsizei count, const GLchar 
         ERROR_CHECK_RETURN(src, GL_OUT_OF_MEMORY);
 
         *src = 0;
-        if (length)
+        for(int i=0; i<count; i++)
         {
-            for(int i=0; i<count; i++)
-            {
-                strncat(src, string[i], length[i]);
-            }
+            strncat(src, string[i], used_length[i]);
         }
+        if (tmp_length) free(tmp_length);
     }
     else
     {


### PR DESCRIPTION
It's still failing at link time, when MGL produces an MTL library, supposedly because some elements are multiply defined: my vertex and shader sources share some sources, my guess is that all shaders and sources are concatenated somewhere, which produces multiple same definitions.