### PR TITLE
fix finding vao attrib with the same buffer

### DIFF
--- a/MGL/src/MGLRenderer.m
+++ b/MGL/src/MGLRenderer.m
@@ -486,6 +486,7 @@ void logDirtyBits(GLMContext ctx)
                             // include it the list of attributes
                             buffer_map->buffers[map].attribute_mask |= (0x1 << att);
                             found_buffer = true;
+                            mapped_buffers++;
                             break;
                         }
                     }


### PR DESCRIPTION
again, not sure of this one, but without it line 511: assert(mapped_buffers == count); would not pass.