### PR TITLE
Multi def in shaders

### DIFF
--- a/MGL/include/glm_context.h
+++ b/MGL/include/glm_context.h
@@ -350,7 +350,10 @@ typedef struct Shader_t {
     glslang_shader_t *compiled_glsl_shader;
     const char *entry_point;
     char *log;
-    void *mtl_data;
+    struct {
+        void *function;
+        void *library;
+    } mtl_data;
 } Shader;
 
 typedef struct Spirv_t {

--- a/MGL/src/MGLRenderer.m
+++ b/MGL/src/MGLRenderer.m
@@ -4005,6 +4005,37 @@ CppCreateMGLRendererAndBindToContext (void *window, void *glm_ctx)
     [self newCommandBuffer];
     
     glm_ctx->mtl_funcs.mtlView = (void *)CFBridgingRetain(view);
+
+    // capture Metal commands in MGL.gputrace
+    // necessitates Info.plist in the cwd, see https://stackoverflow.com/a/64172784
+    //MTLCaptureDescriptor *descriptor = [self setupCaptureToFile: _device];
+    //[self startCapture:descriptor];
+}
+
+- (MTLCaptureDescriptor *)setupCaptureToFile: (id<MTLDevice>)device//(nonnull MTLDevice* )device // (nonnull MTKView *)view
+{
+    MTLCaptureDescriptor *descriptor = [[MTLCaptureDescriptor alloc] init];
+    descriptor.destination = MTLCaptureDestinationGPUTraceDocument;
+    descriptor.outputURL = [NSURL fileURLWithPath:@"MGL.gputrace"];
+    descriptor.captureObject = device; //((MTKView *)view).device;
+    
+    return descriptor;
+}
+
+- (void)startCapture:(MTLCaptureDescriptor *) descriptor
+{
+    NSError *error = nil;
+    BOOL success = [MTLCaptureManager.sharedCaptureManager startCaptureWithDescriptor:descriptor
+                                                                                error:&error];
+    if (!success) {
+        NSLog(@" error capturing mtl => %@ ", [error localizedDescription] );
+    }
+}
+
+// Stop the capture.
+- (void)stopCapture
+{
+    [MTLCaptureManager.sharedCaptureManager stopCapture];
 }
 
 @end

--- a/MGL/src/draw_buffers.c
+++ b/MGL/src/draw_buffers.c
@@ -149,7 +149,7 @@ bool validate_program(GLMContext ctx)
 {
     RETURN_FALSE_ON_NULL(ctx->state.program);
 
-    RETURN_FALSE_ON_NULL(ctx->state.program->mtl_data);
+    //RETURN_FALSE_ON_NULL(ctx->state.program->mtl_data);
 
     if (ctx->state.program->shader_slots[_GEOMETRY_SHADER])
     {

--- a/MGL/src/program.c
+++ b/MGL/src/program.c
@@ -449,7 +449,7 @@ void mglLinkProgram(GLMContext ctx, GLuint program)
 
     ctx->mtl_funcs.mtlBindProgram(ctx, pptr);
 
-    ERROR_CHECK_RETURN(pptr->mtl_data, GL_INVALID_OPERATION);
+    //ERROR_CHECK_RETURN(pptr->mtl_data, GL_INVALID_OPERATION);
 }
 
 void mglUseProgram(GLMContext ctx, GLuint program)
@@ -469,7 +469,7 @@ void mglUseProgram(GLMContext ctx, GLuint program)
 
         ERROR_CHECK_RETURN(pptr->linked_glsl_program, GL_INVALID_OPERATION);
 
-        ERROR_CHECK_RETURN(pptr->mtl_data, GL_INVALID_OPERATION);
+        // ERROR_CHECK_RETURN(pptr->mtl_data, GL_INVALID_OPERATION);
     }
     else
     {

--- a/MGL/src/shaders.c
+++ b/MGL/src/shaders.c
@@ -187,9 +187,10 @@ void mglDeleteShader(GLMContext ctx, GLuint shader)
         glslang_shader_delete(ptr->compiled_glsl_shader);
     }
 
-    if (ptr->mtl_data)
+    if (ptr->mtl_data.library)
     {
-        ctx->mtl_funcs.mtlDeleteMTLObj(ctx, ptr->mtl_data);
+        ctx->mtl_funcs.mtlDeleteMTLObj(ctx, ptr->mtl_data.function);
+        ctx->mtl_funcs.mtlDeleteMTLObj(ctx, ptr->mtl_data.library);
     }
 
     free((void *)ptr->mtl_shader_type_name);


### PR DESCRIPTION
This is the code that handle multiple same definitions (function, data structure) in different shaders (vertex, fragment...).
I eliminated the code that assembles all shader sources into a single one, as this would raise an error during shader compilation with multiple same/shared definitions.
Now the shader objects keep track of two mtl data: the function entry point, and the compiled library.
I did not know how to transform the code that checks that the program is valid, hence I commented it out in various places to make my tests run. Obviously, this should be rewritten.
There is another problem with my scheme: glDeleteShaders will erase the library and the function, though a program can still exists. This will crash the app. So far, I commented out glDeleteShaders in my code, but it should be handled properly.