### PR TITLE
fix handling of 2D 1x1 textures

### DIFF
--- a/MGL/src/MGLRenderer.m
+++ b/MGL/src/MGLRenderer.m
@@ -897,7 +897,7 @@ void logDirtyBits(GLMContext ctx)
 
                         if (depth > 1) // 2d array
                             region = MTLRegionMake3D(0,0,0,width,height,1);
-                        else if (height > 1) // 1d array
+                        else if (height >= 1) // 1d array
                             region = MTLRegionMake2D(0,0,width,1);
                         else // ?
                             assert(0);


### PR DESCRIPTION
I use a dummy 1x1 texture in my code, which I think is valid opengl. This change make it pass, though I think the whole logic of this code might not be correct.