### PR TITLE
advertise GLSL 4.6 and fix offset in draw functions

### DIFF
--- a/MGL/src/MGLRenderer.m
+++ b/MGL/src/MGLRenderer.m
@@ -3307,6 +3307,8 @@ void mtlDrawElements(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
+    size_t offset = (char *)indices - (char *)NULL;
+
     // indexBufferOffset is a byte offset
     switch(indexType)
     {
@@ -3320,7 +3322,7 @@ void mtlDrawElements(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type
     // to much memory down.. like a million point galaxy drawing
     //
     [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:end - count indexType:indexType
-                                     indexBuffer:indexBuffer indexBufferOffset:start instanceCount:1];
+                                     indexBuffer:indexBuffer indexBufferOffset:offset+start instanceCount:1];
 }
 
 void mtlDrawRangeElements(GLMContext glm_ctx, GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices)
@@ -3371,13 +3373,15 @@ void mtlDrawArraysInstanced(GLMContext glm_ctx, GLenum mode, GLint first, GLsize
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
+    size_t offset = (char *)indices - (char *)NULL;
+
     // for now lets just ignore the range data and use drawIndexedPrimitives
     //
     // in the future it would be an idea to use temp buffers for large buffers that would wire
     // to much memory down.. like a million point galaxy drawing
     //
     [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType
-                                     indexBuffer:indexBuffer indexBufferOffset:0 instanceCount:instancecount];
+                                     indexBuffer:indexBuffer indexBufferOffset:offset instanceCount:instancecount];
 }
 
 void mtlDrawElementsInstanced(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount)
@@ -3409,7 +3413,9 @@ void mtlDrawElementsInstanced(GLMContext glm_ctx, GLenum mode, GLsizei count, GL
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
-    [_currentRenderEncoder drawIndexedPrimitives: primitiveType indexCount:count indexType: indexType indexBuffer:indexBuffer indexBufferOffset:0 instanceCount:1 baseVertex:basevertex baseInstance:0];
+    size_t offset = (char *)indices - (char *)NULL;
+
+    [_currentRenderEncoder drawIndexedPrimitives: primitiveType indexCount:count indexType: indexType indexBuffer:indexBuffer indexBufferOffset:offset instanceCount:1 baseVertex:basevertex baseInstance:0];
 }
 
 void mtlDrawElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type, const void *indices, GLint basevertex)
@@ -3441,6 +3447,8 @@ void mtlDrawElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLsizei count, G
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
+    size_t offset = (char *)indices - (char *)NULL;
+
     // indexBufferOffset is a byte offset
     switch(indexType)
     {
@@ -3448,7 +3456,7 @@ void mtlDrawElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLsizei count, G
         case MTLIndexTypeUInt32: start <<= 2; break;
     }
 
-    [_currentRenderEncoder drawIndexedPrimitives: primitiveType indexCount:end - start indexType: indexType indexBuffer:indexBuffer indexBufferOffset:start instanceCount:1 baseVertex:basevertex baseInstance:0];
+    [_currentRenderEncoder drawIndexedPrimitives: primitiveType indexCount:end - start indexType: indexType indexBuffer:indexBuffer indexBufferOffset:offset+start instanceCount:1 baseVertex:basevertex baseInstance:0];
 }
 
 void mtlDrawRangeElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices, GLint basevertex)
@@ -3458,7 +3466,7 @@ void mtlDrawRangeElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLuint star
 
 
 #pragma mark C interface to mtlDrawElementsInstancedBaseVertex
--(void) mtlDrawElementsInstancedBaseVertex: (GLMContext) glm_ctx mode:(GLenum) mode count:(GLuint)count type: (GLenum) type indices:(const void *)indices instancecount:(GLsizei) instancecount basevertex:(GLint) basevertex
+-(void) mtlDrawElementsInstancedBaseVertex: (GLMContext) glm_ctx mode:(GLenum) mode count:(GLuint) count type: (GLenum) type indices:(const void *)indices instancecount:(GLsizei) instancecount basevertex:(GLint) basevertex
 {
     MTLPrimitiveType primitiveType;
     MTLIndexType indexType;
@@ -3480,7 +3488,9 @@ void mtlDrawRangeElementsBaseVertex(GLMContext glm_ctx, GLenum mode, GLuint star
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
-    [_currentRenderEncoder drawIndexedPrimitives: primitiveType indexCount:count indexType: indexType indexBuffer:indexBuffer indexBufferOffset:0 instanceCount:instancecount baseVertex:basevertex baseInstance:0];
+    size_t offset = (char *)indices - (char *)NULL;
+
+    [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType indexBuffer:indexBuffer indexBufferOffset:offset instanceCount:instancecount baseVertex:basevertex baseInstance:0];
 }
 
 void mtlDrawElementsInstancedBaseVertex(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex)
@@ -3602,12 +3612,14 @@ void mtlDrawArraysInstancedBaseInstance(GLMContext glm_ctx, GLenum mode, GLint f
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
+    size_t offset = (char *)indices - (char *)NULL;
+
     // for now lets just ignore the range data and use drawIndexedPrimitives
     //
     // in the future it would be an idea to use temp buffers for large buffers that would wire
     // to much memory down.. like a million point galaxy drawing
     //
-    [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType indexBuffer:indexBuffer indexBufferOffset:0 instanceCount:instancecount baseVertex:0 baseInstance:baseinstance];
+    [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType indexBuffer:indexBuffer indexBufferOffset:offset instanceCount:instancecount baseVertex:0 baseInstance:baseinstance];
 }
 
 void mtlDrawElementsInstancedBaseInstance(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLuint baseinstance)
@@ -3640,12 +3652,14 @@ void mtlDrawElementsInstancedBaseInstance(GLMContext glm_ctx, GLenum mode, GLsiz
     id <MTLBuffer>indexBuffer = (__bridge id<MTLBuffer>)(gl_element_buffer->data.mtl_data);
     assert(indexBuffer);
 
+    size_t offset = (char *)indices - (char *)NULL;
+
     // for now lets just ignore the range data and use drawIndexedPrimitives
     //
     // in the future it would be an idea to use temp buffers for large buffers that would wire
     // to much memory down.. like a million point galaxy drawing
     //
-    [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType indexBuffer:indexBuffer indexBufferOffset:0 instanceCount:instancecount baseVertex:basevertex baseInstance:baseinstance];
+    [_currentRenderEncoder drawIndexedPrimitives:primitiveType indexCount:count indexType:indexType indexBuffer:indexBuffer indexBufferOffset:offset instanceCount:instancecount baseVertex:basevertex baseInstance:baseinstance];
 }
 
 void mtlDrawElementsInstancedBaseVertexBaseInstance(GLMContext glm_ctx, GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex, GLuint baseinstance)

--- a/MGL/src/get.c
+++ b/MGL/src/get.c
@@ -409,7 +409,7 @@ const GLubyte *mglGetString(GLMContext ctx, GLenum name)
             return (const GLubyte *)"4.6.0";
 
         case GL_SHADING_LANGUAGE_VERSION:
-            return (const GLubyte *)"4.5";
+            return (const GLubyte *)"4.6";
 
         default:
             assert(0);
@@ -435,7 +435,7 @@ const GLubyte  *mglGetStringi(GLMContext ctx, GLenum name, GLuint index)
         case GL_VENDOR: return (const GLubyte *)"Mike Larson";
         case GL_RENDERER: return (const GLubyte *) "MGL";
         case GL_VERSION: return (const GLubyte *) "4.6.0";
-        case GL_SHADING_LANGUAGE_VERSION: return (const GLubyte *) "4.5.0";
+        case GL_SHADING_LANGUAGE_VERSION: return (const GLubyte *) "4.6.0";
         case GL_EXTENSIONS: return NULL;
 
         default:

--- a/MGL/src/shaders.c
+++ b/MGL/src/shaders.c
@@ -81,10 +81,10 @@ void initGLSLInput(GLMContext ctx, GLuint type, const char *src, glslang_input_t
     input->target_language_version = GLSLANG_TARGET_SPV_1_5;
 
     input->code = src;
-    input->default_version = 450;
+    input->default_version = 460;
     input->default_profile = GLSLANG_CORE_PROFILE;
     //input->messages = 0xFFFF & ~GLSLANG_MSG_RELAXED_ERRORS_BIT;
-    input->messages = GLSLANG_MSG_DEFAULT_BIT | GLSLANG_MSG_DEBUG_INFO_BIT;
+    input->messages = GLSLANG_MSG_DEFAULT_BIT | GLSLANG_MSG_DEBUG_INFO_BIT | GLSLANG_MSG_RELAXED_ERRORS_BIT;
     input->resource = glslang_default_resource();
 
     input->force_default_version_and_profile = 1;
@@ -294,6 +294,8 @@ void mglCompileShader(GLMContext ctx, GLuint shader)
         free(ptr->log);
         ptr->log = NULL;
     }
+
+    glslang_shader_set_options(glsl_shader, GLSLANG_SHADER_VULKAN_RULES_RELAXED);
 
     err = glslang_shader_preprocess(glsl_shader, &glsl_input);
     if (!err)

--- a/MGL/src/textures.c
+++ b/MGL/src/textures.c
@@ -144,7 +144,7 @@ static Texture *getTexture(GLMContext ctx, GLenum target, GLuint texture)
     return ptr;
 }
 
-static int isTexuture(GLMContext ctx, GLuint texture)
+static int isTexture(GLMContext ctx, GLuint texture)
 {
     Texture *ptr;
 
@@ -370,7 +370,7 @@ void mglDeleteTextures(GLMContext ctx, GLsizei n, const GLuint *textures)
 
 GLboolean mglIsTexture(GLMContext ctx, GLuint texture)
 {
-    return isTexuture(ctx, texture);
+    return isTexture(ctx, texture);
 }
 
 void mglInvalidateTexImage(GLMContext ctx, GLuint texture, GLint level)


### PR DESCRIPTION
4.6 was not fully advertised, which prevented the use of gl_BaseInstance. In the absence of glUniform*, gl_BaseInstance is useful (if not required) for drawing multiple, different objects...