### PR TITLE
add -Wall and -fsanitize=address to compile options

### DIFF
--- a/MGL/src/shaders.c
+++ b/MGL/src/shaders.c
@@ -207,7 +207,6 @@ void mglShaderSource(GLMContext ctx, GLuint shader, GLsizei count, const GLchar 
     size_t len;
     char *src;
     Shader *ptr;
-    const GLint * used_length=0;
     GLint* tmp_length=0;
 
     ERROR_CHECK_RETURN(isShader(ctx, shader), GL_INVALID_VALUE);
@@ -229,14 +228,12 @@ void mglShaderSource(GLMContext ctx, GLuint shader, GLsizei count, const GLchar 
                 tmp_length[i] = strlen(string[i]);
                 len += tmp_length[i];
             }
-            used_length = tmp_length;
         }
         else {
             for(int i=0; i<count; i++)
             {
                 len += length[i];
             }
-            used_length = length;
         }   
 
         ERROR_CHECK_RETURN(len, GL_INVALID_VALUE);

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,9 @@ $(test_exe): $(test_objs)
 	@mkdir -p $(dir $@)
 	$(CXX) -o $@ $^ -L$(build_dir) -lmgl $(shell pkg-config --libs glfw3)
 
-CFLAGS += -gfull -Og
+CFLAGS += -gfull -O0 -Wall
+CFLAGS += -fsanitize=address #-O1
+LIBS += -fsanitize=address
 CFLAGS += -arch $(shell uname -m)
 CFLAGS += -I$(spirv_cross_1_2_include_path)
 CFLAGS += -I$(spirv_cross_config_include_path)


### PR DESCRIPTION
"-Wall" will raise some warnings to be fixed. Hopefully it will also help fix bugs in case some parameters were forgotten during the gl2mtl translation process.

-fsanitize=address will detect memory violation error. This should be put in a "debug" set of options only, I'll do it in another commit.