### PR TITLE
remove vertex array error check

### DIFF
--- a/MGL/src/vertex_arrays.c
+++ b/MGL/src/vertex_arrays.c
@@ -138,7 +138,7 @@ void mglBindVertexArray(GLMContext ctx, GLuint array)
     }
     else
     {
-        ERROR_CHECK_RETURN(isVAO(ctx, array), GL_INVALID_VALUE);
+        //ERROR_CHECK_RETURN(isVAO(ctx, array), GL_INVALID_VALUE);
 
         ptr = getVAO(ctx, array);
 


### PR DESCRIPTION
if a vertex array is created with glGenVertexArrays (rather than glCreateVertexArrays), then the isVAO check in mglBindVertexArray will fail.